### PR TITLE
pulling swrad for SNTemp, gridded, measured SW Radiation comparison

### DIFF
--- a/6_model_output.yml
+++ b/6_model_output.yml
@@ -33,3 +33,226 @@ targets:
       model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
   6_model_output/out/SNTemp_sw_rad_station_location_DWPK_40.09_-75.62.rds:
     command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DWPK_40.09_-75.62.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DCLY_39.81_-75.46.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.81),
+      long = I(-75.46),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DCLY_39.81_-75.46.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DCLY_39.81_-75.46.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DTDF_40.07_-75.47.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(40.07),
+      long = I(-75.47),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DTDF_40.07_-75.47.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DTDF_40.07_-75.47.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DDFS_39.17_-75.59.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.17),
+      long = I(-75.59),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DDFS_39.17_-75.59.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DDFS_39.17_-75.59.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DELN_38.81_-75.43.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(38.81),
+      long = I(-75.43),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DELN_38.81_-75.43.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DELN_38.81_-75.43.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DGLW_39.61_-75.73.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.61),
+      long = I(-75.73),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DGLW_39.61_-75.73.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DGLW_39.61_-75.73.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DSGM_40.07_-75.78.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(40.07),
+      long = I(-75.78),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DSGM_40.07_-75.78.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DSGM_40.07_-75.78.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DGRN_39.8_-75.61.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.80),
+      long = I(-75.61),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DGRN_39.8_-75.61.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DGRN_39.8_-75.61.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DHOC_39.79_-75.7.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.79),
+      long = I(-75.7),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DHOC_39.79_-75.7.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DHOC_39.79_-75.7.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DBUK1_39.82_-75.73.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.82),
+      long = I(-75.73),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DBUK1_39.82_-75.73.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DBUK1_39.82_-75.73.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DLWG_39.87_-75.68.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.87),
+      long = I(-75.68),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DLWG_39.87_-75.68.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DLWG_39.87_-75.68.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DSJR_39.09_-75.44.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.09),
+      long = I(-75.44),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DSJR_39.09_-75.44.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DSJR_39.09_-75.44.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DWBD_39.94_-75.72.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.94),
+      long = I(-75.72),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DWBD_39.94_-75.72.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DWBD_39.94_-75.72.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DMIL_38.88_-75.44.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(38.88),
+      long = I(-75.44),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DMIL_38.88_-75.44.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DMIL_38.88_-75.44.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DDMV_39.67_-75.63.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.67),
+      long = I(-75.63),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DDMV_39.67_-75.63.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DDMV_39.67_-75.63.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DAGF_39.67_-75.75.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.67),
+      long = I(-75.75),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DAGF_39.67_-75.75.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DAGF_39.67_-75.75.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DWCC_39.73_-75.73.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.73),
+      long = I(-75.73),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DWCC_39.73_-75.73.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DWCC_39.73_-75.73.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DSMY_39.28_-75.58.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.28),
+      long = I(-75.58),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DSMY_39.28_-75.58.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DSMY_39.28_-75.58.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DWWK_40.16_-75.73.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(40.16),
+      long = I(-75.73),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DWWK_40.16_-75.73.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DWWK_40.16_-75.73.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DWCH_39.94_-75.55.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.94),
+      long = I(-75.55),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DWCH_39.94_-75.55.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DWCH_39.94_-75.55.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DSCR_39.86_-75.84.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.86),
+      long = I(-75.84),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DSCR_39.86_-75.84.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DSCR_39.86_-75.84.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DCHI_39.73_-75.52.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.73),
+      long = I(-75.52),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DCHI_39.73_-75.52.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DCHI_39.73_-75.52.rds.ind')
+
+  6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind:
+    command: get_segment_output(
+      ind_file = target_name,
+      lat = I(39.75),
+      long = I(-75.61),
+      model_fabric_file = '2_1_model_fabric/in/network_full.rds',
+      model_output_file = '4_model_for_PGDL/out/sntemp_input_output.feather')
+  6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds:
+    command: gd_get('6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind')
+
+
+

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EQ0hJXzM5LjczXy03NS41Mi5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EQ0hJXzM5LjczXy03NS41Mi5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DCHI_39.73_-75.52.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: c68b27bee4b8760c39dfa05c7868d27e
+time: 2020-01-24 18:51:20 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 96f85ecbd951090fa2a7afd85bf76fe7
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EQ0xZXzM5LjgxXy03NS40Ni5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EQ0xZXzM5LjgxXy03NS40Ni5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DCLY_39.81_-75.46.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: 25e13e0943b8ebf62fb58ba72af7a8fe
+time: 2020-01-24 18:47:47 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 91df744f28d9179d7306562010049e8f
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EQUdGXzM5LjY3Xy03NS43NS5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EQUdGXzM5LjY3Xy03NS43NS5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DAGF_39.67_-75.75.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: 47fd898fa42e636c2547356299e009e2
+time: 2020-01-24 18:50:16 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: a4290dfb371ab27794053daa70e4a749
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EQlVLMV8zOS44Ml8tNzUuNzMucmRzLmluZA.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EQlVLMV8zOS44Ml8tNzUuNzMucmRzLmluZA.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DBUK1_39.82_-75.73.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: 3f32f32e53a9d2aba16bc8156a2ef98f
+time: 2020-01-24 18:49:14 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: c7e3ff62eac0626630a98b61941a8945
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ER0xXXzM5LjYxXy03NS43My5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ER0xXXzM5LjYxXy03NS43My5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DGLW_39.61_-75.73.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: 47fd898fa42e636c2547356299e009e2
+time: 2020-01-24 18:48:31 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 4aaf6ae63551ff951e68132961b29b0c
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ER1JOXzM5LjhfLTc1LjYxLnJkcy5pbmQ.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ER1JOXzM5LjhfLTc1LjYxLnJkcy5pbmQ.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DGRN_39.8_-75.61.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: fb524cfcd3b37ec208fc6e92a81a382e
+time: 2020-01-24 18:48:55 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 9191e26cfd50f2f7e6f687242a9c75e3
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ERE1WXzM5LjY3Xy03NS42My5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ERE1WXzM5LjY3Xy03NS42My5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DDMV_39.67_-75.63.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: fc224b90c134a0a09d90763e23900b64
+time: 2020-01-24 18:50:06 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: db63e410c4306bd6b0b4b0becdc9d8b5
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EREZTXzM5LjE3Xy03NS41OS5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EREZTXzM5LjE3Xy03NS41OS5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DDFS_39.17_-75.59.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: eacaa324dfaf22d4803a4d73c62f5586
+time: 2020-01-24 18:48:10 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: b5e5b01f51963b772157f04dd36e33fb
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ERUxOXzM4LjgxXy03NS40My5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ERUxOXzM4LjgxXy03NS40My5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DELN_38.81_-75.43.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: f066d7052186e1521e91a584f229d791
+time: 2020-01-24 18:48:22 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 6cf229c4848372f920ca62f774563dd0
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ESE9DXzM5Ljc5Xy03NS43LnJkcy5pbmQ.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ESE9DXzM5Ljc5Xy03NS43LnJkcy5pbmQ.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DHOC_39.79_-75.7.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: 3f32f32e53a9d2aba16bc8156a2ef98f
+time: 2020-01-24 18:49:04 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 7d26ef2909928b4c8575b0de9fc70702
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ETFdHXzM5Ljg3Xy03NS42OC5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ETFdHXzM5Ljg3Xy03NS42OC5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DLWG_39.87_-75.68.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: 3f32f32e53a9d2aba16bc8156a2ef98f
+time: 2020-01-24 18:49:23 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 48611edfe5aef9b51df4929686b7d734
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ETUlMXzM4Ljg4Xy03NS40NC5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9ETUlMXzM4Ljg4Xy03NS40NC5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DMIL_38.88_-75.44.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: abf28f11961e18db00508391769f57d9
+time: 2020-01-24 18:49:55 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: f4cae93bd50af4492ece1061d13339b3
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EU01ZXzM5LjI4Xy03NS41OC5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EU01ZXzM5LjI4Xy03NS41OC5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DSMY_39.28_-75.58.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: f7f4b04dbd2a4960df32164d0bfdf853
+time: 2020-01-24 18:50:36 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 242a4da86bf9db3d3410634aa67f2c29
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EU0NSXzM5Ljg2Xy03NS44NC5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EU0NSXzM5Ljg2Xy03NS44NC5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DSCR_39.86_-75.84.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: 811f77ae4067eca293fb71317b9bada8
+time: 2020-01-24 18:51:10 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 236a7d0bcc4b3c496f80ebddbdc6a395
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EU0dNXzQwLjA3Xy03NS43OC5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EU0dNXzQwLjA3Xy03NS43OC5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DSGM_40.07_-75.78.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: cde86c708ba063db369f29ed7b4b1f3f
+time: 2020-01-24 18:48:46 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: a22a5af12245918310fbe41e2de068f6
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EU0pSXzM5LjA5Xy03NS40NC5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EU0pSXzM5LjA5Xy03NS40NC5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DSJR_39.09_-75.44.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: 89bb82f72b034b4dcdaed8b602536745
+time: 2020-01-24 18:49:34 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: ae531c504404a5c2b894ea3030c32bca
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EUFJDXzM5Ljc1Xy03NS42MS5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EUFJDXzM5Ljc1Xy03NS42MS5yZHMuaW5k.yml
@@ -1,0 +1,14 @@
+version: 0.3.0
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+type: file
+hash: 030f3a3a699b9f222ebfc68befa41350
+time: 2020-01-24 13:38:40 UTC
+depends:
+  2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
+  4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
+fixed: 207fd85071e52b415e06123b3bf82bd9
+code:
+  functions:
+    get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c
+    get_segment_output: d7aca494d2ea2558395a4449a367ba9e
+

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV0JEXzM5Ljk0Xy03NS43Mi5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV0JEXzM5Ljk0Xy03NS43Mi5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DWBD_39.94_-75.72.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: f90cb9cf533358c8b4d1c1139c52df94
+time: 2020-01-24 18:49:45 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: e5c6a8d93a3b389baf78d1ac465753dd
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV0NDXzM5LjczXy03NS43My5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV0NDXzM5LjczXy03NS43My5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DWCC_39.73_-75.73.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: de765b43097d8f0c8ca55228831ad138
+time: 2020-01-24 18:50:25 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: e754d640df944bb302e7940642a0fdeb
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV0NIXzM5Ljk0Xy03NS41NS5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV0NIXzM5Ljk0Xy03NS41NS5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DWCH_39.94_-75.55.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: c79342477af0c492837cf6789c57bd06
+time: 2020-01-24 18:50:58 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 49918b503ea4721d2a9d3732e791675b
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV0NIXzM5LjkzM18tNzUuNTUucmRzLmluZA.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV0NIXzM5LjkzM18tNzUuNTUucmRzLmluZA.yml
@@ -2,7 +2,7 @@ version: 0.3.0
 name: 6_model_output/out/SNTemp_sw_rad_station_location_DWCH_39.933_-75.55.rds.ind
 type: file
 hash: c79342477af0c492837cf6789c57bd06
-time: 2020-01-23 20:31:03 UTC
+time: 2020-01-24 18:47:29 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV0NIXzM5LjkzM18tNzUuNTUucmRzLmluZA.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV0NIXzM5LjkzM18tNzUuNTUucmRzLmluZA.yml
@@ -1,0 +1,14 @@
+version: 0.3.0
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DWCH_39.933_-75.55.rds.ind
+type: file
+hash: c79342477af0c492837cf6789c57bd06
+time: 2020-01-23 20:31:03 UTC
+depends:
+  2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
+  4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
+fixed: 591b6c4c0b8f36f2051bbbee177cff61
+code:
+  functions:
+    get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c
+    get_segment_output: d7aca494d2ea2558395a4449a367ba9e
+

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV1BLXzQwLjA5Xy03NS42Mi5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV1BLXzQwLjA5Xy03NS42Mi5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DWPK_40.09_-75.62.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: b248a54c48055ff5a2c89a3d262c5952
+time: 2020-01-24 18:47:38 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: a094e7991abef06172dd193443e961bf
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV1dLXzQwLjE2Xy03NS43My5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EV1dLXzQwLjE2Xy03NS43My5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DWWK_40.16_-75.73.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: f8b4554ec7bac8f861f4b5cbfbaf6bce
+time: 2020-01-24 18:50:48 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: 72a7812a77f0e1c5eac007066c2ecbb9
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c

--- a/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EVERGXzQwLjA3Xy03NS40Ny5yZHMuaW5k.yml
+++ b/build/status/Nl9tb2RlbF9vdXRwdXQvb3V0L1NOVGVtcF9zd19yYWRfc3RhdGlvbl9sb2NhdGlvbl9EVERGXzQwLjA3Xy03NS40Ny5yZHMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
-name: 6_model_output/out/SNTemp_sw_rad_station_location_DPRC_39.75_-75.61.rds.ind
+name: 6_model_output/out/SNTemp_sw_rad_station_location_DTDF_40.07_-75.47.rds.ind
 type: file
-hash: 030f3a3a699b9f222ebfc68befa41350
-time: 2020-01-24 18:51:29 UTC
+hash: b248a54c48055ff5a2c89a3d262c5952
+time: 2020-01-24 18:47:59 UTC
 depends:
   2_1_model_fabric/in/network_full.rds: 759a085e879c086ab479aae1ee9fd2ff
   4_model_for_PGDL/out/sntemp_input_output.feather: 25b752bc6ad2d54f4baf70ff1bca39fe
-fixed: 207fd85071e52b415e06123b3bf82bd9
+fixed: cb8b335b7623110e747854180ae3683e
 code:
   functions:
     get_segment_from_lat_long: 76664b819b4cf313dde84ee96e778d1c


### PR DESCRIPTION
Pulling SW Radiation from PRMS-SNTemp estimated SW radiation. 

Not sure why there are only two build-status files since all the targets were built and remake says that all targets are up-to-date. 